### PR TITLE
Added newline parameter to file writing

### DIFF
--- a/crawler/handlers.py
+++ b/crawler/handlers.py
@@ -49,10 +49,10 @@ class CSVStatsPDFHandler:
         name = self.name or parsed_url.netloc
         output = os.path.join(self.directory, name + '.csv')
         if not os.path.isfile(output):
-            with open(output, 'w') as file:
+            with open(output, 'w', newline='') as file:
                 csv.writer(file).writerow(self._FIELDNAMES)
 
-        with open(output, 'a') as file:
+        with open(output, 'a', newline='') as file:
             writer = csv.DictWriter(file, self._FIELDNAMES)
             filename = get_filename(parsed_url)
             row = {


### PR DESCRIPTION
Added `newline=''` to when writing the file occurs which removes the issue of creating additional, blank lines in some systems which will in turn lead to errors when reading the file to download/crawl the same URL. The error occurs in `get_handled_list` because `k > 0` is True, but the rest of the line is empty so throws an error. This commit has fixed this issue.